### PR TITLE
Fix IllegalArgumentException when credentials contain $ or \

### DIFF
--- a/mavengem-wagon/src/main/java/org/torquebox/mojo/mavengem/wagon/MavenGemWagon.java
+++ b/mavengem-wagon/src/main/java/org/torquebox/mojo/mavengem/wagon/MavenGemWagon.java
@@ -24,6 +24,7 @@ import java.net.Proxy.Type;
 import java.net.SocketAddress;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.regex.Matcher;
 
 public class MavenGemWagon extends StreamWagon {
 
@@ -115,7 +116,7 @@ public class MavenGemWagon extends StreamWagon {
             throws MalformedURLException {
         if (authenticationInfo != null && authenticationInfo.getUserName() != null) {
             String credentials = authenticationInfo.getUserName() + ":" + authenticationInfo.getPassword();
-            url = url.replaceFirst("^(https?://)(.*)$", "$1" + credentials + "@$2");
+            url = url.replaceFirst("^(https?://)(.*)$", "$1" + Matcher.quoteReplacement(credentials) + "@$2");
         }
         return new URL(url);
     }


### PR DESCRIPTION
## Problem

`MavenGemWagon.withAuthentication()` injects server credentials into the repository URL using `String.replaceFirst()`:

```java
url = url.replaceFirst("^(https?://)(.*)$", "$1" + credentials + "@$2");
```

In Java regex replacements, `$` denotes a group reference (`$1`, `$2`) and `\` is an escape character. If a password contains these characters (e.g. `pa$$word`), `replaceFirst()` throws:

```
java.lang.IllegalArgumentException: Illegal group reference
```

This breaks any setup where:
- The Maven `settings.xml` defines a `<server>` with credentials for a mavengem mirror
- The password contains `$` (very common in generated passwords) or `\`

## Fix

Wrap the credentials string with `Matcher.quoteReplacement()` before passing it to `replaceFirst()`. This escapes `$` and `\` so they are treated as literals in the replacement string, while keeping the group references `$1` and `$2` functional for the URL parts.

```java
url = url.replaceFirst("^(https?://)(.*)", "$1" + Matcher.quoteReplacement(credentials) + "@$2");
```

## Context

We discovered this while setting up a Maven mirror for rubygems in a corporate environment (Sonatype Nexus). The `settings.xml` defines a `<server>` block with Nexus credentials for the mavengem mirror, and the service account password contains `$`.

Made with [Cursor](https://cursor.com)